### PR TITLE
Check for http in url rather than if url is valid

### DIFF
--- a/app/Helpers/Prepend.php
+++ b/app/Helpers/Prepend.php
@@ -12,10 +12,6 @@ class Prepend
             return null;
         }
 
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
-            return 'http://' . $url;
-        }
-
-        return $url;
+        return strpos($url, 'http') !== 0 ? "http://$url" : $url;
     }
 }


### PR DESCRIPTION
Check url for the existence of http and therefore https rather than if the url is valid to prevent invalid urls containing a protocol to have protocol added to them.
Fixes #2